### PR TITLE
NPT-42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>com.npe.pet</groupId>
 	<artifactId>uncaughtHeroes</artifactId>
-	<version>0.0.4</version>
+	<version>0.0.5</version>
 	<name>uncaughtHeroes</name>
 
 	<properties>

--- a/src/test/java/com/npe/pet/uncaughtHeroes/UncaughtHeroesApplicationTests.java
+++ b/src/test/java/com/npe/pet/uncaughtHeroes/UncaughtHeroesApplicationTests.java
@@ -1,10 +1,15 @@
 package com.npe.pet.uncaughtHeroes;
 
+import com.npe.pet.uncaughtHeroes.repository.HeroRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration")
 class UncaughtHeroesApplicationTests {
+
+	@MockBean
+	private HeroRepository repository;
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
Excluded MongoAutoConfiguration from UncaughtHeroesApplicationTests and mocked HeroRepository to enable building the application without a running MongoDB instance

If needed, later we could still write integration or unit tests for this class, but in the meantime we can still build the application.
![image](https://github.com/padamv/UncaughtHeroes/assets/25488211/9c04dd45-1117-4e20-afe7-7368f61e3aa6)
